### PR TITLE
feat: workflow metadata + input/output mapping schemas

### DIFF
--- a/spec/workflow-mapping-schema.md
+++ b/spec/workflow-mapping-schema.md
@@ -1,0 +1,88 @@
+# Workflow Input/Output Mapping Schema
+
+Canonical schema for mapping workflow controls and outputs. Each workflow **may** have a companion `.map.json` file (e.g., `workflows/sdxl-refiner-api.map.json`).
+
+## Schema (v0.1.0)
+
+```jsonc
+{
+  "version": "0.1.0",
+  "workflow": "string",          // Workflow name (matches filename stem)
+
+  "input_map": {
+    "prompts": [
+      {
+        "role": "positive" | "negative",
+        "tag": "@prompt" | "@negative" | null,
+        "node_id": "string",
+        "field": "text",
+        "description": "string"  // What this prompt controls
+      }
+    ],
+    "models": [
+      {
+        "role": "base" | "refiner" | "lora",
+        "tag": "@checkpoint" | "@lora" | null,
+        "node_id": "string",
+        "field": "ckpt_name" | "lora_name",
+        "description": "string"
+      }
+    ],
+    "sampler": [
+      {
+        "tag": "@ksampler" | null,
+        "node_id": "string",
+        "fields": {
+          "seed": { "type": "int", "description": "Random seed" },
+          "steps": { "type": "int", "range": [1, 150], "description": "Sampling steps" },
+          "cfg": { "type": "float", "range": [1.0, 30.0], "description": "CFG scale" },
+          "sampler_name": { "type": "enum", "description": "Sampler algorithm" },
+          "scheduler": { "type": "enum", "description": "Noise scheduler" },
+          "denoise": { "type": "float", "range": [0.0, 1.0], "description": "Denoise strength" }
+        }
+      }
+    ],
+    "latent": [
+      {
+        "node_id": "string",
+        "fields": {
+          "width": { "type": "int", "description": "Image width" },
+          "height": { "type": "int", "description": "Image height" },
+          "batch_size": { "type": "int", "description": "Batch size" }
+        }
+      }
+    ],
+    "other": []                  // Extensible: masks, controlnet inputs, etc.
+  },
+
+  "output_map": {
+    "save_nodes": [
+      {
+        "tag": "@save" | null,
+        "node_id": "string",
+        "field": "filename_prefix",
+        "description": "Output image save node"
+      }
+    ],
+    "artifact_path": "ComfyUI/output/{filename_prefix}_{counter}.png"
+  }
+}
+```
+
+## Mapping Conventions
+
+- **`tag`**: The `@tag` from `_meta.title` if present; `null` if workflow uses raw node IDs only.
+- **`role`**: Semantic role of the input (positive/negative prompt, base/refiner model, etc.).
+- **`node_id`**: The actual node ID in the workflow JSON — always present as fallback.
+- **`fields`**: For sampler/latent nodes, enumerate all editable fields with type info.
+
+## How Roles Consume Mappings
+
+1. **Prompt Composer** → reads `input_map.prompts` to know where to inject text
+2. **Model Selector** → reads `input_map.models` to swap checkpoints/LoRAs
+3. **Executor** → reads full map to construct `--set` overrides for `cli.js --run`
+4. **Output Handler** → reads `output_map` to locate and deliver artifacts
+
+## Example
+
+See `workflows/sdxl-refiner-api.map.json` for a concrete mapping.

--- a/spec/workflow-metadata-schema.md
+++ b/spec/workflow-metadata-schema.md
@@ -1,0 +1,84 @@
+# Workflow Metadata Schema
+
+Canonical schema for describing ComfyClaw workflows. Each workflow **may** have a companion `.meta.json` file alongside its API JSON (e.g., `workflows/sdxl-refiner-api.meta.json`).
+
+## Schema (v0.1.0)
+
+```jsonc
+{
+  // Required
+  "name": "string",              // Human-readable workflow name
+  "version": "string",           // Schema version (semver)
+  "purpose": "string",           // What this workflow does (1-2 sentences)
+
+  // Style & Use-Case
+  "style": ["string"],           // Style tags: "photorealistic", "illustrative", "anime", "abstract", "portrait", "landscape", etc.
+  "use_cases": ["string"],       // When to use: "general-purpose", "character-portrait", "product-shot", "concept-art", etc.
+
+  // Model Compatibility
+  "models": {
+    "base": {
+      "architecture": "string",  // "sdxl", "sd15", "flux", "sd3", etc.
+      "recommended": ["string"], // Recommended checkpoint filenames
+      "compatible": ["string"]   // Other known-working checkpoints
+    },
+    "refiner": {                 // Optional — only if workflow uses a refiner pass
+      "architecture": "string",
+      "recommended": ["string"]
+    },
+    "loras": [                   // Optional
+      {
+        "name": "string",        // LoRA filename
+        "trigger_words": ["string"],
+        "purpose": "string",     // What the LoRA adds
+        "strength_range": [0.0, 1.0]  // Recommended min/max strength
+      }
+    ]
+  },
+
+  // Runtime Notes
+  "resolution": {
+    "default": [1024, 1024],     // [width, height]
+    "recommended": [[1024, 1024], [1152, 896], [896, 1152]]
+  },
+  "estimated_time_seconds": 10,  // Rough estimate on target hardware
+  "vram_minimum_gb": 8,          // Minimum VRAM to run
+  "caveats": ["string"],         // Known issues, gotchas, limitations
+
+  // Agent Context (issue #12)
+  "context": {
+    "summary": "string",         // Agent-facing plain-English description
+    "prompt_guidance": "string", // Tips for writing good prompts for this workflow
+    "caution": "string"          // Things to avoid or watch out for
+  }
+}
+```
+
+## Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | ✅ | Display name |
+| `version` | ✅ | Schema version, currently `"0.1.0"` |
+| `purpose` | ✅ | One-liner describing what the workflow produces |
+| `style` | recommended | Helps agents select the right workflow for a request |
+| `use_cases` | recommended | Semantic use-case tags |
+| `models.base` | ✅ | Primary model info |
+| `models.refiner` | optional | Only for refiner workflows |
+| `models.loras` | optional | LoRA compatibility info |
+| `resolution` | recommended | Prevents bad dimension choices |
+| `estimated_time_seconds` | optional | Helps with timeout planning |
+| `vram_minimum_gb` | optional | Prevents OOM on undersized hardware |
+| `caveats` | optional | Freeform gotchas |
+| `context` | recommended | Agent-facing guidance for workflow selection and prompting |
+
+## Naming Convention
+
+Metadata files live alongside workflow JSON:
+```
+workflows/
+  sdxl-refiner-api.json
+  sdxl-refiner-api.meta.json
+  text2image-example-api.json
+  text2image-example-api.meta.json
+```

--- a/workflows/sdxl-refiner-api.map.json
+++ b/workflows/sdxl-refiner-api.map.json
@@ -1,0 +1,101 @@
+{
+  "version": "0.1.0",
+  "workflow": "sdxl-refiner",
+  "input_map": {
+    "prompts": [
+      {
+        "role": "positive",
+        "tag": null,
+        "node_id": "6",
+        "field": "text",
+        "description": "Base model positive prompt (CLIPTextEncode)"
+      },
+      {
+        "role": "positive",
+        "tag": null,
+        "node_id": "15",
+        "field": "text",
+        "description": "Refiner positive prompt (CLIPTextEncode) — must match node 6"
+      },
+      {
+        "role": "negative",
+        "tag": null,
+        "node_id": "7",
+        "field": "text",
+        "description": "Base model negative prompt"
+      },
+      {
+        "role": "negative",
+        "tag": null,
+        "node_id": "16",
+        "field": "text",
+        "description": "Refiner negative prompt — must match node 7"
+      }
+    ],
+    "models": [
+      {
+        "role": "base",
+        "tag": "@checkpoint",
+        "node_id": "4",
+        "field": "ckpt_name",
+        "description": "SDXL base checkpoint"
+      },
+      {
+        "role": "refiner",
+        "tag": null,
+        "node_id": "12",
+        "field": "ckpt_name",
+        "description": "SDXL refiner checkpoint"
+      }
+    ],
+    "sampler": [
+      {
+        "tag": null,
+        "node_id": "10",
+        "role": "base",
+        "fields": {
+          "noise_seed": { "type": "int", "description": "Random seed" },
+          "steps": { "type": "int", "range": [1, 150], "description": "Total sampling steps (base + refiner)" },
+          "cfg": { "type": "float", "range": [1.0, 30.0], "description": "CFG scale" },
+          "sampler_name": { "type": "enum", "description": "Sampler algorithm" },
+          "scheduler": { "type": "enum", "description": "Noise scheduler" },
+          "start_at_step": { "type": "int", "description": "Base start step" },
+          "end_at_step": { "type": "int", "description": "Base end step (refiner takes over)" }
+        }
+      },
+      {
+        "tag": null,
+        "node_id": "11",
+        "role": "refiner",
+        "fields": {
+          "steps": { "type": "int", "description": "Must match base steps" },
+          "cfg": { "type": "float", "description": "Refiner CFG" },
+          "start_at_step": { "type": "int", "description": "Refiner start (should match base end_at_step)" },
+          "end_at_step": { "type": "int", "description": "Refiner end step" }
+        }
+      }
+    ],
+    "latent": [
+      {
+        "node_id": "5",
+        "fields": {
+          "width": { "type": "int", "description": "Image width (recommended: 1024)" },
+          "height": { "type": "int", "description": "Image height (recommended: 1024)" },
+          "batch_size": { "type": "int", "description": "Number of images per run" }
+        }
+      }
+    ],
+    "other": []
+  },
+  "output_map": {
+    "save_nodes": [
+      {
+        "tag": "@save",
+        "node_id": "19",
+        "field": "filename_prefix",
+        "description": "Output image save node"
+      }
+    ],
+    "artifact_path": "ComfyUI/output/{filename_prefix}_{counter}.png"
+  }
+}

--- a/workflows/sdxl-refiner-api.meta.json
+++ b/workflows/sdxl-refiner-api.meta.json
@@ -1,0 +1,41 @@
+{
+  "name": "SDXL + Refiner",
+  "version": "0.1.0",
+  "purpose": "Two-pass SDXL generation: base model renders the composition, refiner pass adds detail and coherence.",
+  "style": ["photorealistic", "cinematic", "analogue"],
+  "use_cases": ["general-purpose", "landscape", "portrait", "concept-art"],
+  "models": {
+    "base": {
+      "architecture": "sdxl",
+      "recommended": ["juggernautXL_v9Rundiffusionphoto2.safetensors"],
+      "compatible": [
+        "juggernautXL_v8Rundiffusion.safetensors",
+        "juggernautXL_v7Rundiffusion.safetensors",
+        "dreamshaperXL_turboDpmppSDE.safetensors",
+        "realvisxlV40_v40Bakedvae.safetensors",
+        "CHEYENNE_v16VAEBaked.safetensors",
+        "juggernaut_aftermath.safetensors"
+      ]
+    },
+    "refiner": {
+      "architecture": "sdxl",
+      "recommended": ["SDXL/sd_xl_refiner_1.0.safetensors"]
+    },
+    "loras": []
+  },
+  "resolution": {
+    "default": [1024, 1024],
+    "recommended": [[1024, 1024], [1152, 896], [896, 1152]]
+  },
+  "estimated_time_seconds": 7,
+  "vram_minimum_gb": 10,
+  "caveats": [
+    "Refiner uses separate CLIP encode — both positive prompts (nodes 6 and 15) must be updated together",
+    "Base runs steps 0-20, refiner runs 20-25 — adjusting step split changes style balance"
+  ],
+  "context": {
+    "summary": "Best all-around workflow for high-quality photorealistic and cinematic images. Two-pass process with SDXL base + refiner produces sharp, coherent results.",
+    "prompt_guidance": "Works great with descriptive photography-style prompts. Include lighting, mood, camera/film references. Juggernaut excels at realism and human subjects.",
+    "caution": "Remember to set BOTH positive prompt nodes (6 and 15) to the same text, or base and refiner will diverge."
+  }
+}

--- a/workflows/text2image-example-api.map.json
+++ b/workflows/text2image-example-api.map.json
@@ -1,0 +1,68 @@
+{
+  "version": "0.1.0",
+  "workflow": "text2image-example",
+  "input_map": {
+    "prompts": [
+      {
+        "role": "positive",
+        "tag": "@prompt",
+        "node_id": "6",
+        "field": "text",
+        "description": "Positive prompt"
+      },
+      {
+        "role": "negative",
+        "tag": "@negative",
+        "node_id": "7",
+        "field": "text",
+        "description": "Negative prompt"
+      }
+    ],
+    "models": [
+      {
+        "role": "base",
+        "tag": "@checkpoint",
+        "node_id": "4",
+        "field": "ckpt_name",
+        "description": "SD 1.5 checkpoint"
+      }
+    ],
+    "sampler": [
+      {
+        "tag": "@ksampler",
+        "node_id": "3",
+        "role": "base",
+        "fields": {
+          "seed": { "type": "int", "description": "Random seed" },
+          "steps": { "type": "int", "range": [1, 150], "description": "Sampling steps" },
+          "cfg": { "type": "float", "range": [1.0, 30.0], "description": "CFG scale" },
+          "sampler_name": { "type": "enum", "description": "Sampler algorithm" },
+          "scheduler": { "type": "enum", "description": "Noise scheduler" },
+          "denoise": { "type": "float", "range": [0.0, 1.0], "description": "Denoise strength" }
+        }
+      }
+    ],
+    "latent": [
+      {
+        "node_id": "5",
+        "fields": {
+          "width": { "type": "int", "description": "Image width (recommended: 512)" },
+          "height": { "type": "int", "description": "Image height (recommended: 512)" },
+          "batch_size": { "type": "int", "description": "Number of images per run" }
+        }
+      }
+    ],
+    "other": []
+  },
+  "output_map": {
+    "save_nodes": [
+      {
+        "tag": "@save",
+        "node_id": "9",
+        "field": "filename_prefix",
+        "description": "Output image save node"
+      }
+    ],
+    "artifact_path": "ComfyUI/output/{filename_prefix}_{counter}.png"
+  }
+}

--- a/workflows/text2image-example-api.meta.json
+++ b/workflows/text2image-example-api.meta.json
@@ -1,0 +1,30 @@
+{
+  "name": "Text2Image Basic (SD 1.5)",
+  "version": "0.1.0",
+  "purpose": "Simple single-pass text-to-image generation using Stable Diffusion 1.5. Fast, lightweight, good for quick iterations.",
+  "style": ["illustrative", "general"],
+  "use_cases": ["general-purpose", "quick-iteration", "concept-sketch"],
+  "models": {
+    "base": {
+      "architecture": "sd15",
+      "recommended": ["v1-5-pruned-emaonly.safetensors"],
+      "compatible": ["v1-5-pruned-emaonly-fp16.safetensors"]
+    },
+    "loras": []
+  },
+  "resolution": {
+    "default": [512, 512],
+    "recommended": [[512, 512], [512, 768], [768, 512]]
+  },
+  "estimated_time_seconds": 3,
+  "vram_minimum_gb": 4,
+  "caveats": [
+    "SD 1.5 quality is lower than SDXL — use for speed, not final output",
+    "512x512 native resolution — higher res may produce artifacts without hires fix"
+  ],
+  "context": {
+    "summary": "Fastest workflow available. Single KSampler pass with SD 1.5. Best for rapid prototyping and testing prompts before running through the SDXL refiner pipeline.",
+    "prompt_guidance": "Keep prompts concise. SD 1.5 responds well to comma-separated tag-style prompts. Quality boosters like 'masterpiece, best quality' help.",
+    "caution": "Don't expect SDXL-level quality. Use this for speed, then upgrade to sdxl-refiner for final output."
+  }
+}


### PR DESCRIPTION
## Summary

Adds canonical schemas for workflow metadata and input/output mappings, plus concrete entries for both existing workflows.

### What's included

**Schemas (in `spec/`):**
- **workflow-metadata-schema.md** — describes workflow purpose, style tags, model compatibility, runtime notes, resolution defaults, and agent-facing context (prompt guidance, cautions)
- **workflow-mapping-schema.md** — maps workflow inputs (prompts, models, samplers, latent params) and outputs (save nodes, artifact paths) so roles/agents can programmatically drive generation

**Concrete mappings (in `workflows/`):**
- `sdxl-refiner-api.meta.json` + `sdxl-refiner-api.map.json`
- `text2image-example-api.meta.json` + `text2image-example-api.map.json`

### Issues addressed
Closes #9 (metadata schema)
Closes #10 (mapping schema)
Closes #11 (register initial mappings)
Closes #12 (agent context enrichment)

### Design decisions
- Companion file pattern (`.meta.json` / `.map.json`) keeps workflow JSON clean
- Schema is v0.1.0 — intentionally minimal, easy to extend
- Maps include both `@tag` references AND raw `node_id` for workflows with/without tags
- sdxl-refiner caveat about dual prompt nodes (6+15) documented in both meta and map

🌙 — Grace