### PR TITLE
Add COMFYCLAW_DIR env var for portable CLI usage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -270,7 +270,8 @@ async function cmdRun(name, argv) {
     }
 
     // Parse remaining argv: [outDir] [--set key=val ...]
-    let outDir = path.join(__dirname, 'outputs');
+    const baseDir = process.env.COMFYCLAW_DIR || __dirname;
+    let outDir = path.join(baseDir, 'outputs');
     const setArgs = [];
     let i = 0;
 
@@ -427,6 +428,7 @@ function printUsage() {
     console.log('  --set @tag.key=value     Tag-based override (recommended)');
     console.log('  --set nodeId.key=value   Direct node-ID override\n');
     console.log('Environment:');
+    console.log('  COMFYCLAW_DIR        ComfyClaw repo directory (default: script location)');
     console.log('  COMFYUI_SERVER       Force a specific server URL');
     console.log('  COMFYUI_TIMEOUT_MS   Max wait time (default: 180000)');
 }

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -12,10 +12,11 @@ A CLI tool for discovering, inspecting, and executing ComfyUI workflows.
 ## Quick Reference
 
 ```bash
-cd <ComfyClaw directory>
+# If COMFYCLAW_DIR is set, run from anywhere. Otherwise cd to the repo first.
+# export COMFYCLAW_DIR=/path/to/ComfyClaw
 
 # List available workflows
-node cli.js --list
+node ${COMFYCLAW_DIR:-$PWD}/cli.js --list
 
 # See editable parameters (queries live server for valid values)
 node cli.js --describe <workflow>
@@ -99,8 +100,23 @@ node cli.js --run text2image-example outputs \
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `COMFYUI_SERVER` | (auto-select) | Force a specific server URL |
-| `COMFYUI_TIMEOUT_MS` | `180000` | Max wait for completion (ms) |
+| `COMFYCLAW_DIR` | (script location) | Path to ComfyClaw repo root. Set this so the CLI can find workflows and outputs from anywhere. |
+| `COMFYUI_SERVER` | (auto-select) | Force a specific ComfyUI server URL (e.g. `http://localhost:8188`) |
+| `COMFYUI_TIMEOUT_MS` | `180000` | Max wait for workflow completion (ms) |
+
+### Setup
+
+If the user hasn't set `COMFYCLAW_DIR`, ask them where ComfyClaw is installed and recommend:
+
+```bash
+export COMFYCLAW_DIR=/path/to/ComfyClaw
+```
+
+With `COMFYCLAW_DIR` set, you can run the CLI from any directory:
+
+```bash
+node $COMFYCLAW_DIR/cli.js --list
+```
 
 ---
 

--- a/workflows.js
+++ b/workflows.js
@@ -4,7 +4,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const WORKFLOWS_DIR = path.join(__dirname, 'workflows');
+const BASE_DIR = process.env.COMFYCLAW_DIR || __dirname;
+const WORKFLOWS_DIR = path.join(BASE_DIR, 'workflows');
 
 /**
  * List all available API workflows.


### PR DESCRIPTION
Closes #22

Adds `COMFYCLAW_DIR` environment variable so the CLI can find workflows and outputs from any working directory.

## Changes

- **`workflows.js`** — `WORKFLOWS_DIR` now resolves from `COMFYCLAW_DIR` (falls back to `__dirname`)
- **`cli.js`** — default output dir uses `COMFYCLAW_DIR`, added to `--help` env listing
- **`skills/SKILL.md`** — documented `COMFYCLAW_DIR` in env table with setup guidance

`COMFYUI_SERVER` was already supported — this just adds the missing repo-location variable.

### Usage
```bash
export COMFYCLAW_DIR=/home/dev/.openclaw/workspace/codebase/ComfyClaw
node $COMFYCLAW_DIR/cli.js --list  # works from anywhere
```